### PR TITLE
FIBSDK-76 Fix types to correspond to results of API

### DIFF
--- a/lib/src/models/measurement/technical_details.dart
+++ b/lib/src/models/measurement/technical_details.dart
@@ -7,11 +7,11 @@ part 'technical_details.g.dart';
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
 class TechnicalDetails {
   @JsonKey(name: 'camera_exposure_time')
-  final int? cameraExposureTime;
+  final num? cameraExposureTime;
   @JsonKey(name: 'camera_hardware_level')
   final String? cameraHardwareLevel;
   @JsonKey(name: 'camera_iso')
-  final int? cameraIso;
+  final num? cameraIso;
   @JsonKey(name: 'camera_resolution')
   final String? cameraResolution;
 

--- a/lib/src/models/measurement/technical_details.g.dart
+++ b/lib/src/models/measurement/technical_details.g.dart
@@ -8,9 +8,9 @@ part of 'technical_details.dart';
 
 TechnicalDetails _$TechnicalDetailsFromJson(Map<String, dynamic> json) =>
     TechnicalDetails(
-      cameraExposureTime: json['camera_exposure_time'] as int?,
+      cameraExposureTime: json['camera_exposure_time'] as num?,
       cameraHardwareLevel: json['camera_hardware_level'] as String?,
-      cameraIso: json['camera_iso'] as int?,
+      cameraIso: json['camera_iso'] as num?,
       cameraResolution: json['camera_resolution'] as String?,
     );
 

--- a/lib/src/models/profiledata/profiledata.dart
+++ b/lib/src/models/profiledata/profiledata.dart
@@ -27,7 +27,7 @@ class ProfileData {
   final String? city;
   @JsonKey(name: 'postal_code')
   final String? postalCode;
-  final int? weight;
+  final num? weight;
   final int? length;
   final String? birthday;
   final int? gender;

--- a/lib/src/models/profiledata/profiledata.g.dart
+++ b/lib/src/models/profiledata/profiledata.g.dart
@@ -13,7 +13,7 @@ ProfileData _$ProfileDataFromJson(Map<String, dynamic> json) => ProfileData(
       addressLine2: json['address_line2'] as String?,
       city: json['city'] as String?,
       postalCode: json['postal_code'] as String?,
-      weight: json['weight'] as int?,
+      weight: json['weight'] as num?,
       length: json['length'] as int?,
       birthday: json['birthday'] as String?,
       gender: json['gender'] as int?,


### PR DESCRIPTION
Some results from the API can be decimal numbers. Using `num?` instead of `int?` in these cases is safer and avoids the application/SDK to give errors on typing when retrieving results from the API.